### PR TITLE
Timestamps added to stats, various fixes.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Test2-Aggregate
 
+0.06    2019-
+        extend_stats option.
+        Fix repeat<0.
+        Perl critic test & fix.
+
 0.05    2019-06-21
         Avoid Test::More redefine warnings.
         Defaults shown in POD method description.

--- a/MANIFEST
+++ b/MANIFEST
@@ -8,6 +8,7 @@ t/00-load.t
 t/dirs.t
 t/lists.t
 t/override.t
+t/repeat.t
 t/shuffle.t
 t/slow.t
 t/stats.t
@@ -15,6 +16,7 @@ t/warn.t
 xt/aggregate/aggregate.lst
 xt/aggregate/check_env.t
 xt/aggregate/check_plan.t
+xt/author/critic.t
 xt/author/manifest.t
 xt/author/pod-coverage.t
 xt/author/pod.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,8 @@ my %WriteMakefileArgs = (
         'ExtUtils::MakeMaker' => '0',
     },
     TEST_REQUIRES => {
-        'Test2::Tools::Basic' => '0'
+        'Test2::Tools::Basic' => '0',
+        'Test::Output'        => '0'
     },
     PREREQ_PM => {
         'File::Slurp' => '0',

--- a/lib/Test2/Aggregate.pm
+++ b/lib/Test2/Aggregate.pm
@@ -205,17 +205,16 @@ sub _run_tests {
     $repeat = 1 if $repeat < 0;
     my %stats;
 
-    require Time::HiRes if $args->{stats_output};
+    eval 'use Time::HiRes qw(time)' if $args->{stats_output};
 
     for (1 .. $repeat) {
         my $iter = $repeat > 1 ? "Iter: $_/$repeat - " : '';
         foreach my $test (@$tests) {
-            my $start  = Time::HiRes::time() if $args->{stats_output};
+            my $start = time();
             my $result = subtest $iter. "Running test $test" => sub {
                 do $test;
             };
-            $stats{time}{$test} += (Time::HiRes::time() - $start)/$repeat
-                 if $args->{stats_output};
+            $stats{time}{$test} += (time() - $start)/$repeat;
             $stats{pass_perc}{$test} += $result ? 100/$repeat : 0;
         }
     }

--- a/t/repeat.t
+++ b/t/repeat.t
@@ -1,0 +1,12 @@
+use Test2::Tools::Basic;
+use Test2::Aggregate;
+
+plan(4);
+
+my $root = (grep {/^\.$/i} @INC) ? undef : './';
+
+Test2::Aggregate::run_tests(
+    dirs   => ['xt/aggregate'],
+    root   => $root,
+    repeat => 2
+);

--- a/t/stats.t
+++ b/t/stats.t
@@ -1,16 +1,30 @@
 use Test2::Tools::Basic;
 use Test2::Aggregate;
+use Test::Output;
 
 eval "use Time::HiRes";
 plan skip_all => "Time::HiRes required for stats_output option" if $@;
 
-plan(2);
+plan(8);
 
 my $root = (grep {/^\.$/i} @INC) ? undef : './';
+foreach my $extend (0 .. 1) {
+    stdout_like(sub {
+            Test2::Aggregate::run_tests(
+                dirs         => ['xt/aggregate'],
+                root         => $root,
+                extend_stats => $extend,
+                stats_output => '-'
+            )
+        },
+        qr/TOTAL TIME: [0-9.]+ sec/,
+        "Valid stats output for extended = $extend"
+    );
+}
 
 Test2::Aggregate::run_tests(
     dirs         => ['xt/aggregate'],
     root         => $root,
-    stats_output => '/tmp/tmp.txt'
+    stats_output => '/tmp/tmp'
 );
 

--- a/xt/author/critic.t
+++ b/xt/author/critic.t
@@ -1,0 +1,15 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+
+use Test::Perl::Critic (-exclude => ['ProhibitStringyEval']);
+use Test::More;
+
+unless ( $ENV{RELEASE_TESTING} ) {
+    plan( skip_all => "Author tests not required for installation" );
+}
+
+critic_ok('lib/Test2/Aggregate.pm');
+
+done_testing;


### PR DESCRIPTION
New extend_stats option adds timestamps to the stats output.

The repeat<0 option was fixed and a perl critic test was added.