### PR TITLE
Replace File::Slurp with Path::Tiny

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Test2-Aggregate
 
+0.16    2021-08-26
+        Replaced File::Slurp with Path::Tiny (adding 'slurp_param' option).
+
 0.15    2020-08-10
         Fix for test_warnings output showing only first line of STDERR.
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,8 +24,8 @@ my %WriteMakefileArgs = (
         'Test2::V0'    => '0'
     },
     PREREQ_PM => {
-        'File::Slurp' => '0',
-        'Test2::V0'   => '0'
+        'Path::Tiny' => '0',
+        'Test2::V0'  => '0'
     },
     META_MERGE => {
         "meta-spec" => { version => 2 },

--- a/t/lists.t
+++ b/t/lists.t
@@ -1,7 +1,7 @@
 use Test2::V0;
 use Test2::Aggregate;
 
-plan(4);
+plan(6);
 
 my $root = (grep {/^\.$/i} @INC) ? undef : './';
 
@@ -14,4 +14,10 @@ Test2::Aggregate::run_tests(
     lists        => ['xt/aggregate/aggregate.lst'],
     allow_errors => 1,
     root         => $root
+);
+
+Test2::Aggregate::run_tests(
+    lists       => ['xt/aggregate/aggregate.lst'],
+    root        => $root,
+    slurp_param => {binmode => ":unix"}
 );


### PR DESCRIPTION
closes #6 

Although File::Slurp was used just for reading test lists, it is not good practice to depend on unmaintained modules with issues.